### PR TITLE
Update Exercice14_Apache_SiteVirtuel.md par William Crépault

### DIFF
--- a/Exercice14_Apache_SiteVirtuel.md
+++ b/Exercice14_Apache_SiteVirtuel.md
@@ -82,15 +82,16 @@ services:
       - frontend
       - backend
     ports:
-      - "8080:80"
+      - '8080:80'
+      - '443:443'
     volumes:
       - ./monsite/html:/srv/htdocs
   mariadb:
     image: mariadb:latest
-    network: 
-      -backend
-    environnent:
-    - MYSQL_ROOT_PASSWORD=rootpassword
+    networks: 
+      - backend
+    environment:
+      - MYSQL_ROOT_PASSWORD=rootpassword
 networks:
     frontend:
     backend:


### PR DESCRIPTION
J'ai changé les "" pour des '' au numéro de port '8080:80', remis le ports '443:443' puisqu'on utilise encore https dans le premier test, sous mariadb:, networks manquait un "s", manquait un espace à - backend (entre le '-' et .backend'), correction d'orthographe pour 'environment' (changé un 'n' pour un 'm') et 2 espaces avant le '-' de la ligne '- MYSQL_ROOT...'